### PR TITLE
S3#cleanup fails if you have more than 1000 objects in your bucket

### DIFF
--- a/lib/astrails/safe/s3.rb
+++ b/lib/astrails/safe/s3.rb
@@ -52,7 +52,7 @@ module Astrails
 
         cleanup_with_limit(files, keep) do |f|
           puts "removing s3 file #{bucket}:#{f}" if $DRY_RUN || $_VERBOSE
-          AWS::S3::Bucket.find(bucket)[f].delete unless $DRY_RUN || $LOCAL
+          AWS::S3::Bucket.objects(bucket, :prefix => f)[0].delete unless $DRY_RUN || $LOCAL
         end
       end
 

--- a/spec/unit/s3_spec.rb
+++ b/spec/unit/s3_spec.rb
@@ -40,7 +40,7 @@ describe Astrails::Safe::S3 do
       @files = [4,1,3,2].to_a.map { |i| stub(o = {}).key {"aaaaa#{i}"}; o }
 
       stub(AWS::S3::Bucket).objects("_bucket", :prefix => "_kind/_id/_kind-_id.", :max_keys => 4) {@files}
-      stub(AWS::S3::Bucket).find("_bucket").stub![anything].stub!.delete
+      stub(AWS::S3::Bucket).objects("_bucket", :prefix => anything).stub![0].stub!.delete
     end
 
     it "should check [:keep, :s3]" do
@@ -50,8 +50,8 @@ describe Astrails::Safe::S3 do
     end
 
     it "should delete extra files" do
-      mock(AWS::S3::Bucket).find("_bucket").mock!["aaaaa1"].mock!.delete
-      mock(AWS::S3::Bucket).find("_bucket").mock!["aaaaa2"].mock!.delete
+      mock(AWS::S3::Bucket).objects("_bucket", :prefix => "aaaaa1").mock![0].mock!.delete
+      mock(AWS::S3::Bucket).objects("_bucket", :prefix => "aaaaa2").mock![0].mock!.delete
       @s3.send :cleanup
     end
 


### PR DESCRIPTION
Hi,

I ran into a problem with Safe on one of my servers by which the S3#cleanup fails. The reason for this is that AWS::S3::Bucket.find(bucket)[] only has access to the first 1000 objects so you end up calling delete on nil if you have more than 1000 objects.

Iv made a change so that you call AWS::S3::Bucket.objects with the prefix attribute set to the file path, and then call delete on the first instance. I can't see that it would ever return one more object unless you have a structure such as 
    /path/to/file.txt
    /path/to/file.txt.2

but in this case the first result for a search for `/path/to/file.txt` would actually be `/path/to/file.txt`

Thanks
Matt
