### PR TITLE
  don't try to re-create s3 buckets that already exist

### DIFF
--- a/lib/astrails/safe/s3.rb
+++ b/lib/astrails/safe/s3.rb
@@ -27,7 +27,7 @@ module Astrails
             return
           end
           benchmark = Benchmark.realtime do
-            AWS::S3::Bucket.create(bucket)
+            AWS::S3::Bucket.create(bucket) unless bucket_exists?(bucket)
             File.open(@backup.path) do |file|
               AWS::S3::S3Object.store(full_path, file, bucket)
             end
@@ -68,6 +68,13 @@ module Astrails
         @config[:s3, :secret]
       end
 
+      private
+      
+      def bucket_exists?(bucket)
+        true if AWS::S3::Bucket.find(bucket)
+      rescue AWS::S3::NoSuchBucket
+        false
+      end
     end
   end
 end


### PR DESCRIPTION
- to stop this error: "A conflicting conditional operation is currently in progress against this resource. Please try again. (AWS::S3::OperationAborted)"
- this forum post from AWS support suggests that the error arises when trying to re-create the same bucket over and over.
  
  http://developer.amazonwebservices.com/connect/message.jspa?messageID=104253#104253
