### PR TITLE
Fix cleaning of old files via ftp

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -160,6 +160,14 @@ The procedure to create and transfer the key is as follows:
         password "ssh password for sftp"
       end
 
+      ftp do
+        host "YOUR_REMOTE_HOSTNAME"
+        user "YOUR_REMOTE_USERNAME"
+        # port "NON STANDARD FTP PORT"
+        password "YOUR_REMOTE_PASSWORD"
+        path ":kind/:id" # this is the default
+      end
+
       gpg do
         command "/usr/local/bin/gpg"
         options  "--no-use-agent"

--- a/lib/astrails/safe/ftp.rb
+++ b/lib/astrails/safe/ftp.rb
@@ -57,7 +57,7 @@ module Astrails
             sort
 
           cleanup_with_limit(files, keep) do |f|
-            file = File.join(path, f)
+            file = File.path(f)
             puts "removing ftp file #{host}:#{file}" if dry_run? || verbose?
             ftp.delete(file) unless dry_run? || local_only?
           end


### PR DESCRIPTION
We don't need to join the path to filename, received by ftp.nlst(path), because we get full path from ftp
And, as example, instead of removing mysqldump/postfixadmin/mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1443.sql.gz we should remove mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1443.sql.gz

```
Uploading FTP_SERVER:mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1445.sql.gz via FTP
Sending /var/astrails-safe/mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1445.sql.gz to mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1445.sql.gz
...done
listing files: FTP_SERVER:mysqldump/postfixadmin/mysqldump-postfixadmin.*
mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1443.sql.gz
mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1445.sql.gz
mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1444.sql.gz
removing ftp file FTP_SERVER:mysqldump/postfixadmin/mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1443.sql.gz
/usr/lib/ruby/1.9.1/net/ftp.rb:300:in `getresp': 550 mysqldump/postfixadmin/mysqldump/postfixadmin/mysqldump-postfixadmin.131026-1443.sql.gz: No such file or directory (Net::FTPPermError)
    from /usr/lib/ruby/1.9.1/net/ftp.rb:325:in `block in sendcmd'
    from /usr/lib/ruby/1.9.1/monitor.rb:211:in `mon_synchronize'
    from /usr/lib/ruby/1.9.1/net/ftp.rb:323:in `sendcmd'
    from /usr/lib/ruby/1.9.1/net/ftp.rb:746:in `delete'
........
```
